### PR TITLE
Add --plain flag to send messages as a plain text

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,10 @@ func main() {
 			Usage: "Stream messages to Slack continuously instead of uploading a single snippet",
 		},
 		cli.BoolFlag{
+			Name:  "plain, p",
+			Usage: "Write messages as plain texts instead of code blocks",
+		},
+		cli.BoolFlag{
 			Name:  "noop",
 			Usage: "Skip posting file to Slack. Useful for testing",
 		},
@@ -103,6 +107,10 @@ func main() {
 			exitErr(fmt.Errorf("no channel provided!"))
 		}
 
+		if !c.Bool("stream") && c.Bool("plain") {
+			exitErr(fmt.Errorf("'plain' flag requires 'stream' mode!"))
+		}
+
 		slackcat, err := newSlackCat(token, c.String("channel"))
 		failOnError(err, "Slack API Error", true)
 
@@ -124,7 +132,7 @@ func main() {
 		if c.Bool("stream") {
 			output("starting stream")
 			go slackcat.addToStreamQ(lines)
-			go slackcat.processStreamQ(c.Bool("noop"))
+			go slackcat.processStreamQ(c.Bool("noop"), c.Bool("plain"))
 			go slackcat.trap()
 			select {}
 		} else {

--- a/slackcat.go
+++ b/slackcat.go
@@ -90,21 +90,25 @@ func (sc *SlackCat) addToStreamQ(lines chan string) {
 }
 
 //TODO: handle messages with length exceeding maximum for Slack chat
-func (sc *SlackCat) processStreamQ(noop bool) {
+func (sc *SlackCat) processStreamQ(noop bool, plain bool) {
 	if !(sc.queue.isEmpty()) {
 		msglines := sc.queue.flush()
 		if noop {
 			output(fmt.Sprintf("skipped posting of %s message lines to %s", strconv.Itoa(len(msglines)), sc.channelName))
 		} else {
-			sc.postMsg(msglines)
+			sc.postMsg(msglines, plain)
 		}
 	}
 	time.Sleep(3 * time.Second)
-	sc.processStreamQ(noop)
+	sc.processStreamQ(noop, plain)
 }
 
-func (sc *SlackCat) postMsg(msglines []string) {
-	msg := fmt.Sprintf("```%s```", strings.Join(msglines, "\n"))
+func (sc *SlackCat) postMsg(msglines []string, plain bool) {
+	fmtStr := "```%s```"
+	if plain {
+		fmtStr = "%s"
+	}
+	msg := fmt.Sprintf(fmtStr, strings.Join(msglines, "\n"))
 	err := sc.api.ChatPostMessage(sc.channelId, msg, sc.opts)
 	failOnError(err, "", true)
 	output(fmt.Sprintf("posted %s message lines to %s", strconv.Itoa(len(msglines)), sc.channelName))


### PR DESCRIPTION
Added --plain flag to allow users to write messages as plain texts instead of code blocks.