### PR TITLE
Create parent folders for configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -52,7 +52,7 @@ func (c *Config) Write(path string) {
 	cfgdir := basedir(path)
 	// create config dir if not exist
 	if _, err := os.Stat(cfgdir); err != nil {
-		err = os.Mkdir(cfgdir, 0755)
+		err = os.MkdirAll(cfgdir, 0755)
 		if err != nil {
 			exitErr(fmt.Errorf("failed to initialize config dir [%s]: %s", cfgdir, err))
 		}


### PR DESCRIPTION
In some cases configuration folder might be missing a parent. This
will avoid errors like:

```
failed to initialize config dir [/a/b/c/config]: mkdir /a/b/c/config: no such file or directory
```

in case b is missing for example.

I just had this problem because on my system `/home/user/.config` folder was missing, but default location for configuration is nested under it.