### PR TITLE
Fix multiple value in single-value context issue

### DIFF
--- a/slackcat.go
+++ b/slackcat.go
@@ -117,7 +117,7 @@ func (sc *Slackcat) postFile(filePath, fileName, fileType, fileComment string) {
 	}
 
 	start := time.Now()
-	err := api.FilesUpload(&slack.FilesUploadOpt{
+	_, err := api.FilesUpload(&slack.FilesUploadOpt{
 		Filepath:       filePath,
 		Filename:       fileName,
 		Filetype:       fileType,


### PR DESCRIPTION
The Slack API dependency has changed upstream and caused that issue.
I'd advise to vendor it so this kind of issue wouldn't happen in
the future.