### PR TITLE
Improve GetConversations API Call

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/slack-go/slack"
 )
@@ -91,9 +92,15 @@ func getConversations(types ...string) (list []slack.Channel, err error) {
 			Cursor:          cursor,
 			ExcludeArchived: "true",
 			Types:           types,
+			Limit:           1000,
 		}
 		channels, cur, err := api.GetConversations(param)
 		if err != nil {
+			if rateLimitedError, ok := err.(*slack.RateLimitedError); ok {
+				output(fmt.Sprintf("%v", rateLimitedError))
+				time.Sleep(rateLimitedError.RetryAfter)
+				continue
+			}
 			return list, err
 		}
 		list = append(list, channels...)


### PR DESCRIPTION
Hi, this PR is to improve `getConversations` function.

Our team has many channels, so `getConversations` is slow, and rate limited exceeding sometimes happens.

So, I have changed `Limit` request parameter (https://api.slack.com/methods/conversations.list) and added retry for `RateLimitedError` .